### PR TITLE
Handle nan values in metric calculations

### DIFF
--- a/skforecast/metrics/metrics.py
+++ b/skforecast/metrics/metrics.py
@@ -61,6 +61,7 @@ def _get_metric(metric: str) -> Callable:
 def add_y_train_argument(func):
     """
     Add `y_train` argument to a function if it is not already present.
+    Also creates a NaN-aware wrapper for scikit-learn metrics.
 
     Parameters
     ----------
@@ -70,7 +71,7 @@ def add_y_train_argument(func):
     Returns
     -------
     wrapper : callable
-        Function with `y_train` argument added.
+        Function with `y_train` argument added and NaN handling.
     """
     sig = inspect.signature(func)
     
@@ -84,7 +85,52 @@ def add_y_train_argument(func):
 
     @wraps(func)
     def wrapper(*args, y_train=None, **kwargs):
-        return func(*args, **kwargs)
+        # Handle NaN values in y_true and y_pred for scikit-learn metrics
+        
+        # Get y_true and y_pred from either args or kwargs
+        if len(args) >= 2:
+            y_true, y_pred = args[0], args[1]
+            remaining_args = args[2:]
+        elif len(args) == 1 and 'y_pred' in kwargs:
+            y_true = args[0]
+            y_pred = kwargs.pop('y_pred')
+            remaining_args = ()
+        elif len(args) == 0 and 'y_true' in kwargs and 'y_pred' in kwargs:
+            y_true = kwargs.pop('y_true')
+            y_pred = kwargs.pop('y_pred')
+            remaining_args = ()
+        else:
+            # Fallback for edge cases - can't identify y_true/y_pred
+            return func(*args, **kwargs)
+        
+        # Convert to numpy arrays for easier handling
+        y_true = np.asarray(y_true)
+        y_pred = np.asarray(y_pred)
+        
+        # Create mask for valid (non-NaN) pairs
+        valid_mask = ~(np.isnan(y_true) | np.isnan(y_pred))
+        
+        # If no valid pairs, return NaN
+        if not np.any(valid_mask):
+            return np.nan
+        
+        # Filter to only valid pairs
+        y_true_valid = y_true[valid_mask]
+        y_pred_valid = y_pred[valid_mask]
+        
+        # Also filter remaining_args if they have the same length (e.g. sample_weight)
+        filtered_remaining_args = []
+        for arg in remaining_args:
+            if hasattr(arg, '__len__') and len(arg) == len(y_true):
+                # This looks like it should be filtered along with y_true/y_pred
+                filtered_arg = np.asarray(arg)[valid_mask]
+                filtered_remaining_args.append(filtered_arg)
+            else:
+                # Keep as is
+                filtered_remaining_args.append(arg)
+        
+        # Call the original function with filtered data
+        return func(y_true_valid, y_pred_valid, *filtered_remaining_args, **kwargs)
     
     wrapper.__signature__ = new_sig
     
@@ -106,6 +152,10 @@ def mean_absolute_scaled_error(
     that each element is the true value of the target variable in the training
     set for each time series. In this case, the naive forecast is calculated
     for each time series separately.
+    
+    NaN values in y_train are ignored when calculating the naive forecast.
+    If y_true or y_pred contain NaN values, only the non-NaN pairs are used
+    for the calculation.
 
     Parameters
     ----------
@@ -141,12 +191,44 @@ def mean_absolute_scaled_error(
     if len(y_true) == 0 or len(y_pred) == 0:
         raise ValueError("y_true and y_pred must have at least one element")
 
+    # Handle NaN values in y_true and y_pred - only use valid pairs
+    y_true = np.asarray(y_true)
+    y_pred = np.asarray(y_pred)
+    valid_mask = ~(np.isnan(y_true) | np.isnan(y_pred))
+    
+    if not np.any(valid_mask):
+        return np.nan
+    
+    y_true_valid = y_true[valid_mask]
+    y_pred_valid = y_pred[valid_mask]
+    
     if isinstance(y_train, list):
-        naive_forecast = np.concatenate([np.diff(x) for x in y_train])
-        mase = np.mean(np.abs(y_true - y_pred)) / np.mean(np.abs(naive_forecast))
-
+        # Handle list of arrays/series - filter NaN values from each series
+        naive_forecast_diffs = []
+        for x in y_train:
+            x_array = np.asarray(x)
+            x_valid = x_array[~np.isnan(x_array)]
+            if len(x_valid) > 1:  # Need at least 2 values to compute diff
+                naive_forecast_diffs.append(np.diff(x_valid))
+        
+        if not naive_forecast_diffs:
+            return np.nan
+            
+        naive_forecast = np.concatenate(naive_forecast_diffs)
+        if len(naive_forecast) == 0:
+            return np.nan
+            
+        mase = np.mean(np.abs(y_true_valid - y_pred_valid)) / np.mean(np.abs(naive_forecast))
     else:
-        mase = np.mean(np.abs(y_true - y_pred)) / np.mean(np.abs(np.diff(y_train)))
+        # Handle single array/series - filter NaN values
+        y_train_array = np.asarray(y_train)
+        y_train_valid = y_train_array[~np.isnan(y_train_array)]
+        
+        if len(y_train_valid) < 2:  # Need at least 2 values to compute diff
+            return np.nan
+            
+        naive_forecast = np.diff(y_train_valid)
+        mase = np.mean(np.abs(y_true_valid - y_pred_valid)) / np.mean(np.abs(naive_forecast))
 
     return mase
 
@@ -166,6 +248,10 @@ def root_mean_squared_scaled_error(
     that each element is the true value of the target variable in the training
     set for each time series. In this case, the naive forecast is calculated
     for each time series separately.
+    
+    NaN values in y_train are ignored when calculating the naive forecast.
+    If y_true or y_pred contain NaN values, only the non-NaN pairs are used
+    for the calculation.
 
     Parameters
     ----------
@@ -202,10 +288,43 @@ def root_mean_squared_scaled_error(
     if len(y_true) == 0 or len(y_pred) == 0:
         raise ValueError("y_true and y_pred must have at least one element")
 
+    # Handle NaN values in y_true and y_pred - only use valid pairs
+    y_true = np.asarray(y_true)
+    y_pred = np.asarray(y_pred)
+    valid_mask = ~(np.isnan(y_true) | np.isnan(y_pred))
+    
+    if not np.any(valid_mask):
+        return np.nan
+    
+    y_true_valid = y_true[valid_mask]
+    y_pred_valid = y_pred[valid_mask]
+    
     if isinstance(y_train, list):
-        naive_forecast = np.concatenate([np.diff(x) for x in y_train])
-        rmsse = np.sqrt(np.mean((y_true - y_pred) ** 2)) / np.sqrt(np.mean(naive_forecast ** 2))
+        # Handle list of arrays/series - filter NaN values from each series
+        naive_forecast_diffs = []
+        for x in y_train:
+            x_array = np.asarray(x)
+            x_valid = x_array[~np.isnan(x_array)]
+            if len(x_valid) > 1:  # Need at least 2 values to compute diff
+                naive_forecast_diffs.append(np.diff(x_valid))
+        
+        if not naive_forecast_diffs:
+            return np.nan
+            
+        naive_forecast = np.concatenate(naive_forecast_diffs)
+        if len(naive_forecast) == 0:
+            return np.nan
+            
+        rmsse = np.sqrt(np.mean((y_true_valid - y_pred_valid) ** 2)) / np.sqrt(np.mean(naive_forecast ** 2))
     else:
-        rmsse = np.sqrt(np.mean((y_true - y_pred) ** 2)) / np.sqrt(np.mean(np.diff(y_train) ** 2))
+        # Handle single array/series - filter NaN values
+        y_train_array = np.asarray(y_train)
+        y_train_valid = y_train_array[~np.isnan(y_train_array)]
+        
+        if len(y_train_valid) < 2:  # Need at least 2 values to compute diff
+            return np.nan
+            
+        naive_forecast = np.diff(y_train_valid)
+        rmsse = np.sqrt(np.mean((y_true_valid - y_pred_valid) ** 2)) / np.sqrt(np.mean(naive_forecast ** 2))
     
     return rmsse

--- a/skforecast/metrics/tests/test_mean_absolute_scaled_error.py
+++ b/skforecast/metrics/tests/test_mean_absolute_scaled_error.py
@@ -50,4 +50,67 @@ def test_mean_absolute_scaled_error_pandas_series_input():
     y_train_series = pd.Series(y_train)
     expected_mase = np.mean(np.abs(y_true - y_pred)) / np.mean(np.abs(np.diff(y_train)))
     assert np.isclose(mean_absolute_scaled_error(y_true_series, y_pred_series, y_train_series), expected_mase)
+
+def test_mean_absolute_scaled_error_with_nan_in_y_train():
+    """Test MASE with NaN values in y_train - should ignore NaN values."""
+    y_true = np.array([1.0, 2.0, 3.0, 4.0])
+    y_pred = np.array([1.1, 1.9, 3.2, 3.8])
+    y_train = np.array([0.5, np.nan, 1.5, 2.5, 3.5, np.nan, 4.5])
+    
+    # Expected calculation ignoring NaN values in y_train
+    y_train_clean = np.array([0.5, 1.5, 2.5, 3.5, 4.5])
+    expected_mase = np.mean(np.abs(y_true - y_pred)) / np.mean(np.abs(np.diff(y_train_clean)))
+    
+    result = mean_absolute_scaled_error(y_true, y_pred, y_train)
+    assert np.isclose(result, expected_mase)
+
+def test_mean_absolute_scaled_error_with_nan_in_y_true_y_pred():
+    """Test MASE with NaN values in y_true and y_pred - should ignore NaN pairs."""
+    y_true = np.array([1.0, np.nan, 3.0, 4.0])
+    y_pred = np.array([1.1, 1.9, np.nan, 3.8])
+    y_train = np.array([0.5, 1.5, 2.5, 3.5, 4.5])
+    
+    # Expected calculation ignoring NaN pairs
+    y_true_clean = np.array([1.0, 4.0])  # Only positions 0 and 3 are valid
+    y_pred_clean = np.array([1.1, 3.8])
+    expected_mase = np.mean(np.abs(y_true_clean - y_pred_clean)) / np.mean(np.abs(np.diff(y_train)))
+    
+    result = mean_absolute_scaled_error(y_true, y_pred, y_train)
+    assert np.isclose(result, expected_mase)
+
+def test_mean_absolute_scaled_error_with_list_y_train_nan():
+    """Test MASE with list y_train containing NaN values."""
+    y_true = np.array([1.0, 2.0, 3.0, 4.0])
+    y_pred = np.array([1.1, 1.9, 3.2, 3.8])
+    y_train = [
+        np.array([0.5, np.nan, 1.5, 2.5]),
+        np.array([np.nan, 3.5, 4.5, 5.5])
+    ]
+    
+    # Expected calculation with NaN values filtered out
+    diffs_1 = np.diff([0.5, 1.5, 2.5])  # Ignore NaN
+    diffs_2 = np.diff([3.5, 4.5, 5.5])  # Ignore NaN
+    naive_forecast = np.concatenate([diffs_1, diffs_2])
+    expected_mase = np.mean(np.abs(y_true - y_pred)) / np.mean(np.abs(naive_forecast))
+    
+    result = mean_absolute_scaled_error(y_true, y_pred, y_train)
+    assert np.isclose(result, expected_mase)
+
+def test_mean_absolute_scaled_error_all_nan():
+    """Test MASE when all values are NaN - should return NaN."""
+    y_true = np.array([np.nan, np.nan, np.nan, np.nan])
+    y_pred = np.array([np.nan, np.nan, np.nan, np.nan])
+    y_train = np.array([0.5, 1.5, 2.5, 3.5, 4.5])
+    
+    result = mean_absolute_scaled_error(y_true, y_pred, y_train)
+    assert np.isnan(result)
+
+def test_mean_absolute_scaled_error_y_train_all_nan():
+    """Test MASE when y_train is all NaN - should return NaN."""
+    y_true = np.array([1.0, 2.0, 3.0, 4.0])
+    y_pred = np.array([1.1, 1.9, 3.2, 3.8])
+    y_train = np.array([np.nan, np.nan, np.nan, np.nan])
+    
+    result = mean_absolute_scaled_error(y_true, y_pred, y_train)
+    assert np.isnan(result)
     

--- a/skforecast/metrics/tests/test_root_mean_squared_scaled_error.py
+++ b/skforecast/metrics/tests/test_root_mean_squared_scaled_error.py
@@ -50,3 +50,66 @@ def test_pandas_series_input():
     y_train_series = pd.Series(y_train)
     expected_rmsse = np.sqrt(np.mean((y_true - y_pred) ** 2)) / np.sqrt(np.mean(np.diff(y_train) ** 2))
     assert np.isclose(root_mean_squared_scaled_error(y_true_series, y_pred_series, y_train_series), expected_rmsse)
+
+def test_root_mean_squared_scaled_error_with_nan_in_y_train():
+    """Test RMSSE with NaN values in y_train - should ignore NaN values."""
+    y_true = np.array([1.0, 2.0, 3.0, 4.0])
+    y_pred = np.array([1.1, 1.9, 3.2, 3.8])
+    y_train = np.array([0.5, np.nan, 1.5, 2.5, 3.5, np.nan, 4.5])
+    
+    # Expected calculation ignoring NaN values in y_train
+    y_train_clean = np.array([0.5, 1.5, 2.5, 3.5, 4.5])
+    expected_rmsse = np.sqrt(np.mean((y_true - y_pred) ** 2)) / np.sqrt(np.mean(np.diff(y_train_clean) ** 2))
+    
+    result = root_mean_squared_scaled_error(y_true, y_pred, y_train)
+    assert np.isclose(result, expected_rmsse)
+
+def test_root_mean_squared_scaled_error_with_nan_in_y_true_y_pred():
+    """Test RMSSE with NaN values in y_true and y_pred - should ignore NaN pairs."""
+    y_true = np.array([1.0, np.nan, 3.0, 4.0])
+    y_pred = np.array([1.1, 1.9, np.nan, 3.8])
+    y_train = np.array([0.5, 1.5, 2.5, 3.5, 4.5])
+    
+    # Expected calculation ignoring NaN pairs
+    y_true_clean = np.array([1.0, 4.0])  # Only positions 0 and 3 are valid
+    y_pred_clean = np.array([1.1, 3.8])
+    expected_rmsse = np.sqrt(np.mean((y_true_clean - y_pred_clean) ** 2)) / np.sqrt(np.mean(np.diff(y_train) ** 2))
+    
+    result = root_mean_squared_scaled_error(y_true, y_pred, y_train)
+    assert np.isclose(result, expected_rmsse)
+
+def test_root_mean_squared_scaled_error_with_list_y_train_nan():
+    """Test RMSSE with list y_train containing NaN values."""
+    y_true = np.array([1.0, 2.0, 3.0, 4.0])
+    y_pred = np.array([1.1, 1.9, 3.2, 3.8])
+    y_train = [
+        np.array([0.5, np.nan, 1.5, 2.5]),
+        np.array([np.nan, 3.5, 4.5, 5.5])
+    ]
+    
+    # Expected calculation with NaN values filtered out
+    diffs_1 = np.diff([0.5, 1.5, 2.5])  # Ignore NaN
+    diffs_2 = np.diff([3.5, 4.5, 5.5])  # Ignore NaN
+    naive_forecast = np.concatenate([diffs_1, diffs_2])
+    expected_rmsse = np.sqrt(np.mean((y_true - y_pred) ** 2)) / np.sqrt(np.mean(naive_forecast ** 2))
+    
+    result = root_mean_squared_scaled_error(y_true, y_pred, y_train)
+    assert np.isclose(result, expected_rmsse)
+
+def test_root_mean_squared_scaled_error_all_nan():
+    """Test RMSSE when all values are NaN - should return NaN."""
+    y_true = np.array([np.nan, np.nan, np.nan, np.nan])
+    y_pred = np.array([np.nan, np.nan, np.nan, np.nan])
+    y_train = np.array([0.5, 1.5, 2.5, 3.5, 4.5])
+    
+    result = root_mean_squared_scaled_error(y_true, y_pred, y_train)
+    assert np.isnan(result)
+
+def test_root_mean_squared_scaled_error_y_train_all_nan():
+    """Test RMSSE when y_train is all NaN - should return NaN."""
+    y_true = np.array([1.0, 2.0, 3.0, 4.0])
+    y_pred = np.array([1.1, 1.9, 3.2, 3.8])
+    y_train = np.array([np.nan, np.nan, np.nan, np.nan])
+    
+    result = root_mean_squared_scaled_error(y_true, y_pred, y_train)
+    assert np.isnan(result)

--- a/skforecast/metrics/tests/test_sklearn_metrics_nan_handling.py
+++ b/skforecast/metrics/tests/test_sklearn_metrics_nan_handling.py
@@ -1,0 +1,94 @@
+# Unit test NaN handling in scikit-learn metrics wrapped by add_y_train_argument
+# ==============================================================================
+import pytest
+import numpy as np
+import pandas as pd
+from skforecast.metrics import _get_metric
+from sklearn.metrics import mean_squared_error, mean_absolute_error
+
+
+def test_sklearn_metrics_nan_handling_mean_squared_error():
+    """Test that wrapped MSE ignores NaN values."""
+    metric = _get_metric('mean_squared_error')
+    
+    # Test with NaN values in y_true and y_pred
+    y_true = np.array([1.0, np.nan, 3.0, 4.0])
+    y_pred = np.array([1.1, 1.9, np.nan, 3.8])
+    
+    # Expected calculation ignoring NaN pairs
+    y_true_clean = np.array([1.0, 4.0])  # Only positions 0 and 3 are valid
+    y_pred_clean = np.array([1.1, 3.8])
+    expected_mse = mean_squared_error(y_true_clean, y_pred_clean)
+    
+    result = metric(y_true=y_true, y_pred=y_pred)
+    assert np.isclose(result, expected_mse)
+
+
+def test_sklearn_metrics_nan_handling_mean_absolute_error():
+    """Test that wrapped MAE ignores NaN values."""
+    metric = _get_metric('mean_absolute_error')
+    
+    # Test with NaN values in y_true and y_pred
+    y_true = np.array([1.0, np.nan, 3.0, 4.0, 5.0])
+    y_pred = np.array([1.1, 1.9, np.nan, 3.8, np.nan])
+    
+    # Expected calculation ignoring NaN pairs
+    y_true_clean = np.array([1.0, 4.0])  # Only positions 0 and 3 are valid
+    y_pred_clean = np.array([1.1, 3.8])
+    expected_mae = mean_absolute_error(y_true_clean, y_pred_clean)
+    
+    result = metric(y_true=y_true, y_pred=y_pred)
+    assert np.isclose(result, expected_mae)
+
+
+def test_sklearn_metrics_all_nan_values():
+    """Test that wrapped metrics return NaN when all values are NaN."""
+    metric = _get_metric('mean_squared_error')
+    
+    y_true = np.array([np.nan, np.nan, np.nan, np.nan])
+    y_pred = np.array([np.nan, np.nan, np.nan, np.nan])
+    
+    result = metric(y_true=y_true, y_pred=y_pred)
+    assert np.isnan(result)
+
+
+def test_sklearn_metrics_pandas_series_with_nan():
+    """Test that wrapped metrics work with pandas Series containing NaN."""
+    metric = _get_metric('mean_absolute_error')
+    
+    y_true = pd.Series([1.0, np.nan, 3.0, 4.0])
+    y_pred = pd.Series([1.1, 1.9, np.nan, 3.8])
+    
+    # Expected calculation ignoring NaN pairs
+    expected_mae = mean_absolute_error([1.0, 4.0], [1.1, 3.8])
+    
+    result = metric(y_true=y_true, y_pred=y_pred)
+    assert np.isclose(result, expected_mae)
+
+
+def test_sklearn_metrics_no_nan_values():
+    """Test that wrapped metrics work correctly with no NaN values (baseline test)."""
+    metric = _get_metric('mean_squared_error')
+    
+    y_true = np.array([1.0, 2.0, 3.0, 4.0])
+    y_pred = np.array([1.1, 1.9, 3.2, 3.8])
+    
+    expected_mse = mean_squared_error(y_true, y_pred)
+    result = metric(y_true=y_true, y_pred=y_pred)
+    
+    assert np.isclose(result, expected_mse)
+
+
+def test_sklearn_metrics_mean_absolute_percentage_error_with_nan():
+    """Test MAPE with NaN handling."""
+    metric = _get_metric('mean_absolute_percentage_error')
+    
+    y_true = np.array([1.0, np.nan, 3.0, 4.0])
+    y_pred = np.array([1.1, 2.0, np.nan, 3.8])
+    
+    # Expected calculation ignoring NaN pairs
+    from sklearn.metrics import mean_absolute_percentage_error
+    expected_mape = mean_absolute_percentage_error([1.0, 4.0], [1.1, 3.8])
+    
+    result = metric(y_true=y_true, y_pred=y_pred)
+    assert np.isclose(result, expected_mape)


### PR DESCRIPTION
Update custom and wrapped scikit-learn metrics to ignore NaN values in inputs (`y_train`, `y_true`, `y_pred`) to avoid NaN outputs with unclean training data.

---
<a href="https://cursor.com/background-agent?bcId=bc-3ebb78b2-47eb-44b1-97de-7517013691af">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-3ebb78b2-47eb-44b1-97de-7517013691af">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

